### PR TITLE
Add Dockerfile and Makefile for Docker management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "assistente2.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+IMAGE_NAME=treinamentosia
+CONTAINER_NAME=treinamentosia-container
+
+.PHONY: build run stop
+
+build:
+	docker build -t $(IMAGE_NAME) .
+
+run:
+	docker run --name $(CONTAINER_NAME) -d $(IMAGE_NAME)
+
+stop:
+	docker stop $(CONTAINER_NAME) || true
+	docker rm $(CONTAINER_NAME) || true


### PR DESCRIPTION
## Summary
- Add Dockerfile to containerize the project with Python 3.10 and requirements
- Provide Makefile targets to build, run, and stop the Docker container

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `make build` *(fails: make: docker: No such file or directory)*
- `apt-get update && apt-get install -y docker.io` *(attempted to install docker, command still unavailable)*


------
https://chatgpt.com/codex/tasks/task_e_688e7359f738832a800088fafe81e59a