### PR TITLE
feat: add Docker workflow and env configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
-DB_HOST=localhost
-DB_USER=usuario
-DB_PASSWORD=senha
+DB_HOST=db
+DB_USER=root
+DB_PASSWORD=example
 DB_NAME=IAdb
 OPENAI_API_KEY=chave_openai
 APP_SCRIPT=assistente2.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-.env
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,6 @@ COPY requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .
+ENV APP_SCRIPT=assistente2.py
 
-CMD ["python3"]
+CMD ["sh", "-c", "python3 ${APP_SCRIPT}"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: build up down logs run
+
+build:
+	docker-compose build
+
+up:
+	docker-compose up -d
+
+down:
+	docker-compose down
+
+logs:
+	docker-compose logs -f
+
+run:
+	docker-compose run --rm app python $(script)

--- a/db_config.py
+++ b/db_config.py
@@ -4,8 +4,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 DB_CONFIG = {
-    "host": os.getenv("DB_HOST", "localhost"),
-    "user": os.getenv("DB_USER", "usuario"),
-    "password": os.getenv("DB_PASSWORD", "senha"),
-    "database": os.getenv("DB_NAME", "IAdb"),
+    "host": os.environ["DB_HOST"],
+    "user": os.environ["DB_USER"],
+    "password": os.environ["DB_PASSWORD"],
+    "database": os.environ["DB_NAME"],
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,15 @@ services:
       - .:/app
     depends_on:
       - db
-    environment:
-      - MYSQL_HOST=db
-      - MYSQL_USER=root
-      - MYSQL_PASSWORD=example
-      - MYSQL_DATABASE=IAdb
+    env_file:
+      - .env
   db:
     image: mysql:8.0
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: example
-      MYSQL_DATABASE: IAdb
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+    volumes:
+      - ./IAdb.sql:/docker-entrypoint-initdb.d/IAdb.sql
     ports:
       - "3306:3306"


### PR DESCRIPTION
## Summary
- add Makefile for building and running containers
- wire Docker to use `.env` variables and initialize MySQL with `IAdb.sql`
- require DB settings from environment via `db_config.py`

## Testing
- `python -m py_compile db_config.py`
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_688e7c637458832a9d21d484f8f84b68