### PR TITLE
Ajusta Docker e Makefile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY app/ .
 ENV APP_SCRIPT=assistente2.py
 
 CMD ["sh", "-c", "python3 ${APP_SCRIPT}"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,16 +1,19 @@
+.RECIPEPREFIX := >
 .PHONY: build up down logs run
 
+COMPOSE = docker-compose --env-file ../.env
+
 build:
-	docker-compose build
+>$(COMPOSE) build
 
 up:
-	docker-compose up -d
+>$(COMPOSE) up -d
 
 down:
-	docker-compose down
+>$(COMPOSE) down
 
 logs:
-	docker-compose logs -f
+>$(COMPOSE) logs -f
 
 run:
-	docker-compose run --rm app python $(script)
+>$(COMPOSE) run --rm app python $(script)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,11 +3,11 @@ services:
   app:
     build: .
     volumes:
-      - .:/app
+      - ./app:/app
     depends_on:
       - db
     env_file:
-      - .env
+      - ../.env
   db:
     image: mysql:8.0
     restart: always
@@ -15,6 +15,6 @@ services:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
       MYSQL_DATABASE: ${DB_NAME}
     volumes:
-      - ./IAdb.sql:/docker-entrypoint-initdb.d/IAdb.sql
+      - ./mysql/IAdb.sql:/docker-entrypoint-initdb.d/IAdb.sql
     ports:
       - "3306:3306"


### PR DESCRIPTION
## Summary
- Atualiza docker-compose para montar app, carregar .env e iniciar MySQL com script IAdb.sql
- Ajusta Dockerfile para copiar o código da pasta `app`
- Simplifica Makefile usando `--env-file` e prefixo alternativo

## Testing
- `docker-compose --env-file ../.env config` *(falhou: command not found)*
- `pip install docker-compose` *(falhou: subprocess-exited-with-error)*

------
https://chatgpt.com/codex/tasks/task_e_688e881eb220832a92be0e68105a0731